### PR TITLE
[WIP]Add compatibility for Exec/Query

### DIFF
--- a/task.go
+++ b/task.go
@@ -2,6 +2,7 @@ package gomaxcompute
 
 import (
 	"encoding/xml"
+	"strings"
 
 	"github.com/twinj/uuid"
 )
@@ -73,6 +74,13 @@ func newSQLTask(name, query string, config map[string]string) odpsTask {
 			"settings": `{"odps.sql.udf.strict.mode": "true"}`,
 		}
 	}
+	// maxcompute sql ends with ';', different from mysql/hive/...
+	query = strings.TrimSpace(query)
+	n := len(query)
+	if n > 0 && query[n-1] != ';' {
+		query = query + ";"
+	}
+
 	return &odpsSQLTask{
 		Name:   name,
 		Query:  query,


### PR DESCRIPTION
- Append a semicolon to SQL for compatible reason
Maxcompute SQL ends with `;`, which is different from MySQL,hive