### PR TITLE
Handle bad query

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -65,6 +64,12 @@ func (conn *odpsConn) Query(query string, args []driver.Value) (driver.Rows, err
 		return nil, err
 	}
 
+	// check if instance success
+	res, err := conn.getInstanceResult(ins)
+	if err != nil {
+		return nil, err
+	}
+
 	// get tunnel server
 	tunnelServer, err := conn.getTunnelServer()
 	if err != nil {
@@ -76,13 +81,6 @@ func (conn *odpsConn) Query(query string, args []driver.Value) (driver.Rows, err
 		return nil, err
 	}
 
-	res, err := conn.getInstanceResult(ins)
-	if err != nil {
-		return nil, err
-	}
-	if strings.HasPrefix(res, "ODPS-") {
-		return nil, errors.New(res)
-	}
 	return newRows(meta, res)
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,27 @@ func TestQueryBase64(t *testing.T) {
 		row.Scan(&s)
 		a.Equal("\001", s)
 	}
+}
+
+func TestBadQuery(t *testing.T) {
+	a := assert.New(t)
+	db, err := sql.Open("maxcompute", cfg4test.FormatDSN())
+	a.NoError(err)
+
+	// Table not found
+	tn := fmt.Sprintf("unitest%d", rand.Int())
+	_, err = db.Query(fmt.Sprintf("SELECT * FROM %s;", tn))
+	a.Error(err)
+	a.True(strings.Contains(err.Error(), "Table not found"))
+}
+
+func TestBadExec(t *testing.T) {
+	a := assert.New(t)
+	db, err := sql.Open("maxcompute", cfg4test.FormatDSN())
+	a.NoError(err)
+
+	tn := fmt.Sprintf("unitest%d", rand.Int())
+	_, err = db.Exec(fmt.Sprintf("DROP TABLE %s;", tn))
+	a.Error(err)
+	a.True(strings.Contains(err.Error(), "Table not found"))
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -68,6 +68,7 @@ func TestBadExec(t *testing.T) {
 	db, err := sql.Open("maxcompute", cfg4test.FormatDSN())
 	a.NoError(err)
 
+	// Table not found
 	tn := fmt.Sprintf("unitest%d", rand.Int())
 	_, err = db.Exec(fmt.Sprintf("DROP TABLE %s;", tn))
 	a.Error(err)

--- a/instance.go
+++ b/instance.go
@@ -97,9 +97,13 @@ func decodeInstanceResult(result []byte) (string, error) {
 	}
 
 	if ir.Result.Format == "text" {
+		log.Debug(ir.Result.Content)
+		// ODPS errors are text begin with "ODPS-"
+		if strings.HasPrefix(ir.Result.Content, "ODPS-") {
+			return "", errors.WithStack(errors.New(ir.Result.Content))
+		}
 		// FIXME(tony): the result non-query statement usually in text format.
 		// Go's database/sql API only supports lastId and affectedRows.
-		log.Debug(ir.Result.Content)
 		return "", nil
 	}
 


### PR DESCRIPTION
Current implementation returns a nil error even if the instance ends with an `ODPS-` error.