### PR TITLE
Better error message

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -181,7 +182,11 @@ func parseResponse(rsp *http.Response) ([]byte, error) {
 func parseResponseError(statusCode int, body []byte) error {
 	re := responseError{}
 	if err := json.Unmarshal(body, &re); err != nil {
-		return errors.WithStack(fmt.Errorf("response error: %d, %s", statusCode, string(body)))
+		ie := instanceError{}
+		if err := xml.Unmarshal([]byte(body), &ie); err != nil {
+			return errors.WithStack(fmt.Errorf("response error: %d, %s", statusCode, string(body)))
+		}
+		return errors.WithStack(fmt.Errorf("%s: %s", ie.Code, ie.Message))
 	}
 	return errors.WithStack(fmt.Errorf("response error: %d, %s. %s",
 		statusCode, re.Code, re.Message))

--- a/connection_test.go
+++ b/connection_test.go
@@ -74,3 +74,17 @@ func TestBadExec(t *testing.T) {
 	a.Error(err)
 	a.True(strings.Contains(err.Error(), "Table not found"))
 }
+
+func TestInvalidSyntax(t *testing.T) {
+	a := assert.New(t)
+	db, err := sql.Open("maxcompute", cfg4test.FormatDSN())
+	a.NoError(err)
+
+	_, err = db.Query(`SLEECT CAST("\001" AS string) AS a;`)
+	a.Error(err)
+	a.Equal(`ParseError: {ODPS-0130161:[1,1] Parse exception - invalid token 'SLEECT'}`, err.Error())
+
+	_, err = db.Exec(`DROP ;`)
+	a.Error(err)
+	a.Equal(`ParseError: {ODPS-0130161:[1,6] Parse exception - invalid token ';'}`, err.Error())
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -81,10 +81,14 @@ func TestInvalidSyntax(t *testing.T) {
 	a.NoError(err)
 
 	_, err = db.Query(`SLEECT CAST("\001" AS string) AS a;`)
-	a.Error(err)
+	a.NotNil(err)
 	a.Equal(`ParseError: {ODPS-0130161:[1,1] Parse exception - invalid token 'SLEECT'}`, err.Error())
 
 	_, err = db.Exec(`DROP ;`)
-	a.Error(err)
+	a.NotNil(err)
 	a.Equal(`ParseError: {ODPS-0130161:[1,6] Parse exception - invalid token ';'}`, err.Error())
+
+	_, err = db.Query(`SELECT * FROM i_dont_exist;`)
+	a.NotNil(err)
+	a.Equal(`ODPS-0130131:[1,15] Table not found - table gomaxcompute_driver_w7u.i_dont_exist cannot be resolved`, err.Error())
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,31 @@
+package gomaxcompute
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	reErrorCode = regexp.MustCompile(`^.*ODPS-([0-9]+):.*$`)
+)
+
+func parseErrorCode(message string) (string, error) {
+	sub := reErrorCode.FindStringSubmatch(message)
+	if len(sub) != 2 {
+		return "", fmt.Errorf("fail parse error: %s", message)
+	}
+
+	return sub[1], nil
+}
+
+// MaxcomputeError is an error type which represents a single Maxcompute error
+// Please refer to https://www.alibabacloud.com/help/doc-detail/64654.htm
+// for the list of SQL common error code
+type MaxcomputeError struct {
+	Code    string
+	Message string
+}
+
+func (e *MaxcomputeError) Error() string {
+	return fmt.Sprintf("%s", e.Message)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,18 @@
+package gomaxcompute
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseErrorCode(t *testing.T) {
+	a := assert.New(t)
+
+	code, err := parseErrorCode(`ParseError: {ODPS-0130161:[1,6] Parse exception - invalid token ';'}`)
+	a.Nil(err)
+	a.Equal(`0130161`, code)
+
+	code, err = parseErrorCode(`ODPS-0130131:[1,15] Table not found - table gomaxcompute_driver_w7u.i_dont_exist cannot be resolved`)
+	a.Nil(err)
+	a.Equal(`0130131`, code)
+}

--- a/instance.go
+++ b/instance.go
@@ -25,6 +25,18 @@ type instanceResult struct {
 	Result  Result   `xml:"Tasks>Task>Result"`
 }
 
+type instanceErrorMessage struct {
+	CDATA string `xml:",cdata"`
+}
+
+type instanceError struct {
+	XMLName   xml.Name             `xml:"Error"`
+	Code      string               `xml:"Code"`
+	Message   instanceErrorMessage `xml:"Message"`
+	RequestId string               `xml:"RequestId"`
+	HostId    string               `xml:"HostId"`
+}
+
 // instance types：SQL
 func (conn *odpsConn) createInstance(job *odpsJob) (string, error) {
 	if job == nil {

--- a/instance.go
+++ b/instance.go
@@ -113,7 +113,11 @@ func decodeInstanceResult(result []byte) (string, error) {
 		log.Debug(ir.Result.Content)
 		// ODPS errors are text begin with "ODPS-"
 		if strings.HasPrefix(ir.Result.Content, "ODPS-") {
-			return "", errors.WithStack(errors.New(ir.Result.Content))
+			code, err := parseErrorCode(ir.Result.Content)
+			if err != nil {
+				return "", errors.WithStack(errors.New(ir.Result.Content))
+			}
+			return "", &MaxcomputeError{code, ir.Result.Content}
 		}
 		// FIXME(tony): the result non-query statement usually in text format.
 		// Go's database/sql API only supports lastId and affectedRows.

--- a/instance_test.go
+++ b/instance_test.go
@@ -2,10 +2,30 @@ package gomaxcompute
 
 import (
 	"encoding/base64"
+	"encoding/xml"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
+
+func TestDecodeInstanceError(t *testing.T) {
+	a := assert.New(t)
+
+	s := `<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+	<Code>ParseError</Code>
+	<Message><![CDATA[ODPS-0130161:[1,1] Parse exception - invalid token 'SLEECT']]></Message>
+	<RequestId>5583C0893F7EC2D353</RequestId>
+	<HostId>odps.aliyun.com</HostId>
+</Error>`
+
+	var ie instanceError
+	a.NoError(xml.Unmarshal([]byte(s), &ie))
+	a.Equal(`ParseError`, ie.Code)
+	a.Equal(`ODPS-0130161:[1,1] Parse exception - invalid token 'SLEECT'`, ie.Message.CDATA)
+	a.Equal(`5583C0893F7EC2D353`, ie.RequestId)
+	a.Equal(`odps.aliyun.com`, ie.HostId)
+}
 
 func TestDecodeInstanceResult(t *testing.T) {
 	a := assert.New(t)


### PR DESCRIPTION
Fix #43.

To get the error code in another package, try
```go
_, err := db.Query(...)
me, ok := err.(maxcompute.MaxcomputeError)
if !ok {
    ....
}

// 0130131 means table not found
// ref: https://www.alibabacloud.com/help/doc-detail/64654.htm
if me.Code == `0130131` {
    // do stuff
}
```