### PR TITLE
Enable vanity import for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: go
+go_import_path: sqlflow.org/gomaxcompute


### PR DESCRIPTION
Just found that TravisCI supports vanity imports via `go_import_path`. [ref](https://docs.travis-ci.com/user/languages/go/#go-import-path). This would enable CI to test the package at `go/src/sqlflow.org/gomaxcompute` instead of `go/src/github.com/sql-machine-learning/gomaxcompute`.

Related PR: https://github.com/sql-machine-learning/sqlflow/pull/908